### PR TITLE
TreeMap: added tests for deletion of single node trees

### DIFF
--- a/java/test/edu/berkeley/cs/util/TreeMap_T.java
+++ b/java/test/edu/berkeley/cs/util/TreeMap_T.java
@@ -169,6 +169,45 @@ public class TreeMap_T {
   }
 
   @Test
+  public void testDeleteSingleton() {
+    Random random = new Random();
+
+    int key = random.nextInt();
+
+    // test deleteMin on a single node tree
+    map.put(key, random.nextInt());
+    Assert.assertTrue(map.contains(key));
+    Assert.assertEquals(Integer.valueOf(key), map.min());
+
+    map.deleteMin();
+
+    Assert.assertTrue(map.isEmpty());
+    Assert.assertTrue(map.isBST());
+    Assert.assertFalse(map.contains(key));
+
+    // test deleteMax on a single node tree
+    map.put(key, random.nextInt());
+    Assert.assertTrue(map.contains(key));
+    Assert.assertEquals(Integer.valueOf(key), map.max());
+
+    map.deleteMax();
+
+    Assert.assertTrue(map.isEmpty());
+    Assert.assertTrue(map.isBST());
+    Assert.assertFalse(map.contains(key));
+
+    // test delete on a single node tree
+    map.put(key, random.nextInt());
+    Assert.assertTrue(map.contains(key));
+
+    map.delete(key);
+
+    Assert.assertTrue(map.isBST());
+    Assert.assertFalse(map.contains(key));
+    Assert.assertNull(map.get(key));
+  }
+
+  @Test
   public void testIterator() {
     Random random = new Random();
 


### PR DESCRIPTION
found an opportunity for a bug in deleteMin and deleteMax where tests
would usually pass, but randomly generated certain edge cases caused
failures. All known edge cases are covered by trying to delete a
singleton with deleteMin and deleteMax, so that case has been
added to their tests.

I've added code that trips the test case to the private repo under a branch of the same name [here](https://github.com/mattelser/cs404.1/blob/treeMapTestDeletesOnSingleton/java/src/edu/berkeley/cs/util/TreeMap.java). That code will randomly pass/fail the old test and consistently fail the new test. 